### PR TITLE
Omit the streaming extra field whenever possible

### DIFF
--- a/support/zip_stream_writer.php
+++ b/support/zip_stream_writer.php
@@ -323,6 +323,7 @@
 			$deflatesupported = (isset($options["compress_method"]) && $options["compress_method"] === self::COMPRESS_METHOD_STORE ? false : DeflateStream::IsSupported());
 
 			$filename = trim(str_replace("\\", "/", $filename), "/");
+			$compressed_size = (isset($options["compressed_size"]) ? $options["compressed_size"] : 0);
 
 			if (!isset($options["64bit"]))  $options["64bit"] = (isset($options["uncompressed_size"]) && ($options["uncompressed_size"] < 0 || $options["uncompressed_size"] > 0x7FFFFFFF));
 			if (!isset($options["64bit"]))  $options["64bit"] = (isset($options["compressed_size"]) && ($options["compressed_size"] < 0 || $options["compressed_size"] > 0x7FFFFFFF));
@@ -338,7 +339,7 @@
 
 			$options["compress_method"] = ($deflatesupported ? self::COMPRESS_METHOD_DEFLATE : self::COMPRESS_METHOD_STORE);
 			$options["crc32"] = (isset($options["crc32"]) ? (int)$options["crc32"] : 0);
-			$options["compressed_size"] = (isset($options["compressed_size"]) ? $options["compressed_size"] : 0);
+			$options["compressed_size"] = 0;
 			$options["filename"] = $filename;
 			$options["disk_start_num"] = $this->disknum;
 			$options["header_offset"] = $this->outdatasize;
@@ -346,10 +347,12 @@
 
 			$this->currdir = self::InitCentralDirHeader($options);
 
-			if ($options["64bit"])  self::AppendZip64ExtraField($this->currdir["extra_fields"], (isset($options["uncompressed_size"]) ? $options["uncompressed_size"] : 0), (isset($options["compressed_size"]) ? $options["compressed_size"] : 0));
+			if ($options["64bit"])  self::AppendZip64ExtraField($this->currdir["extra_fields"], (isset($options["uncompressed_size"]) ? $options["uncompressed_size"] : 0), $compressed_size);
 
 			// Write the file header.
+			$this->currdir["compressed_size"] = $compressed_size;
 			$this->WriteLocalFileHeader();
+			$this->currdir["compressed_size"] = 0;
 
 			// Set up data streams.
 			$this->currcrc32 = new CRC32Stream();


### PR DESCRIPTION
I added the support for a `compressed_size` option to OpenFile() in order to add the streaming extra field only if strictly necessary.

The extra field can be omitted only if **both** `compressed_size` and `crc32` options are known.
The disadvantage is that the data has to be read twice (store) or compressed in advance and cached (deflate).
The advantage is that all those tools that ignore the central directory will now be able to extract the files from a ZIP archive.

I did not expect at all that the famous [7-Zip](https://7-zip.org/) could be one of them.